### PR TITLE
add close_notify as raw SSL_shutdown

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+===== Unreleased =====
+
+  * add Lwt_ssl.close_notify to issue one-way SSL shutdown (#2, @madroach)
+
 ===== 1.1.3 (2018-07-30) =====
 
   * Upgrade from Jbuilder to Dune (3b5782c).

--- a/lwt_ssl.opam
+++ b/lwt_ssl.opam
@@ -20,7 +20,7 @@ depends: [
   "dune"
   "lwt" {>= "3.0.0"}
   "ocaml"
-  "ssl" {>= "0.5.0"}
+  "ssl" {>= "0.5.13"}
 ]
 
 build: [

--- a/src/lwt_ssl.ml
+++ b/src/lwt_ssl.ml
@@ -168,6 +168,13 @@ let ssl_shutdown (fd, s) =
 
 let shutdown (fd, _) cmd = Lwt_unix.shutdown fd cmd
 
+let close_notify = function
+  | (_, Plain) as s ->
+      shutdown s Unix.SHUTDOWN_SEND;
+      Lwt.return_true
+  | (fd, SSL s) ->
+      repeat_call fd (fun () -> Ssl.close_notify s)
+
 let close (fd, _) = Lwt_unix.close fd
 
 let abort (fd, _) = Lwt_unix.abort fd

--- a/src/lwt_ssl.mli
+++ b/src/lwt_ssl.mli
@@ -74,6 +74,7 @@ val close : socket -> unit Lwt.t
 val in_channel_of_descr : ?buffer:Lwt_bytes.t -> socket -> Lwt_io.input_channel
 val out_channel_of_descr : ?buffer:Lwt_bytes.t -> socket -> Lwt_io.output_channel
 
+val close_notify : socket -> bool Lwt.t
 val ssl_shutdown : socket -> unit Lwt.t
 
 val abort : socket -> exn -> unit


### PR DESCRIPTION
this is needed for sending EOF, aka one-way shutdown.

See https://github.com/savonet/ocaml-ssl/pull/63 and https://github.com/mirage/ocaml-conduit/pull/319