### PR TITLE
Ensure shutdown function does not raise exception on ENOTCONN

### DIFF
--- a/src/lwt_ssl.ml
+++ b/src/lwt_ssl.ml
@@ -166,7 +166,10 @@ let ssl_shutdown (fd, s) =
     Plain -> Lwt.return_unit
   | SSL s -> repeat_call fd (fun () -> Ssl.shutdown s)
 
-let shutdown (fd, _) cmd = Lwt_unix.shutdown fd cmd
+let shutdown (fd, _) cmd = 
+  try Lwt_unix.shutdown fd cmd
+  with 
+  | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
 
 let close_notify = function
   | (_, Plain) as s ->

--- a/src/lwt_ssl.ml
+++ b/src/lwt_ssl.ml
@@ -167,13 +167,22 @@ let ssl_shutdown (fd, s) =
   | SSL s -> repeat_call fd (fun () -> Ssl.shutdown s)
 
 let shutdown (fd, _) cmd = 
-  try Lwt_unix.shutdown fd cmd
-  with 
-  | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
+  Lwt.finalize
+    (fun () ->
+       Lwt.catch
+         (fun () ->
+            Lwt_unix.shutdown fd cmd;
+            Lwt.return_unit)
+         (function
+           (* Occurs if the peer closes the connection first. *)
+           |  Unix.Unix_error (Unix.ENOTCONN, _, _) -> Lwt.return_unit
+           |  exn -> Lwt.reraise exn)[@ocaml.warning "-4"]) 
+    (fun () -> 
+       Lwt_unix.close fd)
 
 let close_notify = function
   | (_, Plain) as s ->
-      shutdown s Unix.SHUTDOWN_SEND;
+      shutdown s Unix.SHUTDOWN_SEND >>= fun () ->
       Lwt.return_true
   | (fd, SSL s) ->
       repeat_call fd (fun () -> Ssl.close_notify s)
@@ -184,7 +193,7 @@ let abort (fd, _) = Lwt_unix.abort fd
 
 let shutdown_and_close s =
   ssl_shutdown s >>= fun () ->
-  Lwt.wrap2 shutdown s Unix.SHUTDOWN_ALL >>= fun () ->
+  shutdown s Unix.SHUTDOWN_ALL >>= fun () ->
   close s
 
 let out_channel_of_descr ?buffer s =

--- a/src/lwt_ssl.mli
+++ b/src/lwt_ssl.mli
@@ -68,7 +68,7 @@ val write_bytes : socket -> Lwt_bytes.t -> int -> int -> int Lwt.t
 val wait_read : socket -> unit Lwt.t
 val wait_write : socket -> unit Lwt.t
 
-val shutdown : socket -> Unix.shutdown_command -> unit
+val shutdown : socket -> Unix.shutdown_command -> unit Lwt.t
 val close : socket -> unit Lwt.t
 
 val in_channel_of_descr : ?buffer:Lwt_bytes.t -> socket -> Lwt_io.input_channel


### PR DESCRIPTION
I stumbled across a case where the syscall `shutdown` of my application failed with `ENOTCONN` and the syscall to `close` did not occur resulting into a file descriptor leak.

By looking at the potential culprit, I found the shutdown function of this library.

The patch is inspired to what is done in [lwt_io](https://github.com/ocsigen/lwt/blob/master/src/unix/lwt_io.ml#L1540):

```ocaml
let close_socket fd =
  Lwt.finalize
    (fun () ->
       Lwt.catch
         (fun () ->
            Lwt_unix.shutdown fd Unix.SHUTDOWN_ALL;
            Lwt.return_unit)
         (function
           (* Occurs if the peer closes the connection first. *)
           | Unix.Unix_error (Unix.ENOTCONN, _, _) -> Lwt.return_unit
           | exn -> Lwt.reraise exn))
    (fun () ->
       Lwt_unix.close fd)
```

